### PR TITLE
feat: Print SHA256 of missing dependencies.

### DIFF
--- a/src/main/java/it/pagopa/maven/depcheck/DependenciesDataVerifierMojo.java
+++ b/src/main/java/it/pagopa/maven/depcheck/DependenciesDataVerifierMojo.java
@@ -72,7 +72,7 @@ public class DependenciesDataVerifierMojo extends DependenciesDataMojo {
 				String expected = map.remove(id);
 				String found = d.getSha256();
 				if (expected == null) {
-					getLog().warn(String.format("SHA-256 of %s is missing.", id));
+					getLog().warn(String.format("SHA-256 of %s is missing. Expected %s", id, found));
 					result[0] = false;
 				} else {
 					if (found.isEmpty()) {


### PR DESCRIPTION
When the SHA256 of a dependency is missing in the file, the calculated value is printed in the log. It's easier to update the file in such a way.