### PR TITLE
feat: Exclude dependencies

### DIFF
--- a/src/main/java/it/pagopa/maven/depcheck/DependenciesDataMojo.java
+++ b/src/main/java/it/pagopa/maven/depcheck/DependenciesDataMojo.java
@@ -7,7 +7,9 @@ package it.pagopa.maven.depcheck;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -21,97 +23,126 @@ import it.pagopa.maven.depcheck.bean.Dependency;
 import it.pagopa.maven.depcheck.util.Sha256;
 
 /**
- * 
  * @author Antonio Tarricone
  */
 public abstract class DependenciesDataMojo extends AbstractMojo {
-	/*
-	 * The Maven project.
-	 */
-	@Parameter(defaultValue = "${project}", required = true, readonly = true)
-	protected MavenProject project;
 
-	/*
-	 * The name of the file containing dependencies data.
-	 */
-	@Parameter(property = "fileName", required = false, defaultValue = "dep-sha256.json")
-	protected String fileName;
+  /*
+   * The Maven project.
+   */
+  @Parameter(defaultValue = "${project}", required = true, readonly = true)
+  protected MavenProject project;
 
-	/*
-	 * The name of the file containing manually added dependencies data.
-	 */
-	@Parameter(property = "addFileName", required = false)
-	protected String addFileName;
+  /*
+   * The name of the file containing dependencies data.
+   */
+  @Parameter(property = "fileName", required = false, defaultValue = "dep-sha256.json")
+  protected String fileName;
 
-	/*
-	 * If true, the plugins are included as dependencies.
-	 */
-	@Parameter(property = "includePlugins", required = false, defaultValue = "false")
-	protected boolean includePlugins;
+  /*
+   * The name of the file containing manually added dependencies data.
+   */
+  @Parameter(property = "addFileName", required = false)
+  protected String addFileName;
 
-	/*
-	 * If true, the parent dependencies are included.
-	 */
-	@Parameter(property = "includeParent", required = false, defaultValue = "false")
-	protected boolean includeParent;
+  /*
+   * If true, the plugins are included as dependencies.
+   */
+  @Parameter(property = "includePlugins", required = false, defaultValue = "false")
+  protected boolean includePlugins;
 
-	/**
-	 * 
-	 * @return
-	 */
-	protected List<Dependency> retrieveDependencies() {
-		return retrieveDependencies(project);
-	}
+  /*
+   * If true, the parent dependencies are included.
+   */
+  @Parameter(property = "includeParent", required = false, defaultValue = "false")
+  protected boolean includeParent;
 
-	/**
-	 * 
-	 * @param specProject
-	 * @return
-	 */
-	protected List<Dependency> retrieveDependencies(MavenProject specProject) {
-		getLog().info("Retrieving of " + specProject.getName() + " dependencies...");
+  /*
+   * Dependencies to be excluded.
+   * In pom.xml the expected format will be:
+   * <excludes>
+   *	<exampleGroupID_1>exampleArtifactID_1,exampleArtifactID_2</exampleGroupID_1>
+   * 	<exampleGroupID_2>exampleArtifactID_1</exampleGroupID_2>
+   * </excludes>
+   */
+  @Parameter(property = "excludes", required = false)
+  protected Map<String, List<String>> excludes;
 
-		Stream<Artifact> artifacts = null;
 
-		Set<Artifact> artifactSet = specProject.getArtifacts();
+  /**
+   * @return
+   */
+  protected List<Dependency> retrieveDependencies() {
+    return retrieveDependencies(project);
+  }
 
-		if (includePlugins) {
-			getLog().info("Plugins will be included.");
-			Set<Artifact> pluginArtifactSet = specProject.getPluginArtifacts();
-			if (pluginArtifactSet == null) {
-				pluginArtifactSet = Set.of();
-			}
-			artifacts = Stream.of(artifactSet.stream(), pluginArtifactSet.stream()).flatMap(a -> a);
-		} else {
-			getLog().info("Plugins will not be included.");
-			artifacts = artifactSet.stream();
-		}
+  /**
+   * @param specProject
+   * @return
+   */
+  protected List<Dependency> retrieveDependencies(MavenProject specProject) {
+    getLog().info("Retrieving of " + specProject.getName() + " dependencies...");
 
-		List<Dependency> dependencies = artifacts.map(a -> {
-			try {
-				String sha256 = "";
-				if (a.getFile() == null) {
-					getLog().warn(String.format("SHA-256 of %s cannot be computed.", a.getId()));
-				} else {
-					sha256 = Sha256.calculate(a.getFile());
-				}
+    Stream<Artifact> artifacts = null;
 
-				Dependency dependency = new Dependency(a.getId(), a.getArtifactId(), a.getGroupId(), a.getVersion(), sha256);
-				getLog().info(dependency.toString());
-				return dependency;
-			} catch (NoSuchAlgorithmException | IOException e) {
-				getLog().error(String.format("Error calculating SHA-256 %s.", a.getId()));
-				getLog().error(e);
-				throw new RuntimeException(e);
-			}
-		}).collect(Collectors.toList());
+    Set<Artifact> artifactSet = specProject.getArtifacts();
 
-		if (includeParent && specProject.hasParent()) {
-			getLog().info("Retrieving of parent dependencies...");
-			List<Dependency> parentDependencies = retrieveDependencies(specProject.getParent());
-			dependencies.addAll(parentDependencies);
-		}
+    Map<String, List<String>> excludeMap = excludes != null ? excludes : Collections.emptyMap();
 
-		return dependencies;
-	}
+    if (!excludeMap.isEmpty()) {
+      getLog().info("Excluded dependencies: ");
+      excludeMap.forEach((groupId, artifactList) ->
+          artifactList.forEach(artifact ->
+              getLog().info(String.format("%s:%s", groupId, artifact))
+          )
+      );
+    } else {
+      getLog().info("No dependencies to be excluded");
+    }
+
+
+    if (includePlugins) {
+      getLog().info("Plugins will be included.");
+      Set<Artifact> pluginArtifactSet = specProject.getPluginArtifacts();
+      if (pluginArtifactSet == null) {
+        pluginArtifactSet = Set.of();
+      }
+      artifacts = Stream.of(artifactSet.stream(), pluginArtifactSet.stream()).flatMap(a -> a);
+    } else {
+      getLog().info("Plugins will not be included.");
+      artifacts = artifactSet.stream();
+    }
+
+    List<Dependency> dependencies = artifacts
+        .filter(a ->
+            !excludeMap.containsKey(a.getGroupId()) || !excludeMap.get(a.getGroupId())
+                .contains(a.getArtifactId()))
+        .map(a -> {
+          try {
+            String sha256 = "";
+            if (a.getFile() == null) {
+              getLog().warn(String.format("SHA-256 of %s cannot be computed.", a.getId()));
+            } else {
+              sha256 = Sha256.calculate(a.getFile());
+            }
+
+            Dependency dependency = new Dependency(a.getId(), a.getArtifactId(), a.getGroupId(),
+                a.getVersion(), sha256);
+            getLog().info(dependency.toString());
+            return dependency;
+          } catch (NoSuchAlgorithmException | IOException e) {
+            getLog().error(String.format("Error calculating SHA-256 %s.", a.getId()));
+            getLog().error(e);
+            throw new RuntimeException(e);
+          }
+        }).collect(Collectors.toList());
+
+    if (includeParent && specProject.hasParent()) {
+      getLog().info("Retrieving of parent dependencies...");
+      List<Dependency> parentDependencies = retrieveDependencies(specProject.getParent());
+      dependencies.addAll(parentDependencies);
+    }
+
+    return dependencies;
+  }
 }

--- a/src/test/java/it/pagopa/maven/depcheck/DependenciesDataGeneratorMojoTest.java
+++ b/src/test/java/it/pagopa/maven/depcheck/DependenciesDataGeneratorMojoTest.java
@@ -7,6 +7,8 @@ package it.pagopa.maven.depcheck;
 
 import java.io.File;
 import java.io.FileReader;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
@@ -68,6 +70,56 @@ public class DependenciesDataGeneratorMojoTest extends AbstractMojoTestCase {
 				.disableHtmlEscaping()
 				.create()
 				.fromJson(reader2, DependenciesData.class);
+			dependenciesData2.sort();
+
+			assertEquals(dependenciesData1.toString(), dependenciesData2.toString());
+		}
+	}
+
+	public void testWoParentWoPluginsWExcludedDependenciesHashOk() throws Exception {
+		MyArtifactStub artifact1 = new MyArtifactStub();
+		artifact1.setId("art_1");
+		artifact1.setArtifactId("artifact_1");
+		artifact1.setFile(getTestFile("src/test/resources/unit-test/artifact_1.txt"));
+		artifact1.setGroupId("group_1");
+		artifact1.setVersion("version_1");
+
+		MyArtifactStub artifact2 = new MyArtifactStub();
+		artifact2.setId("art_2");
+		artifact2.setArtifactId("artifact_2");
+		artifact2.setFile(getTestFile("src/test/resources/unit-test/artifact_2.txt"));
+		artifact2.setGroupId("group_2");
+		artifact2.setVersion("version_2");
+
+		MavenProject project = new MavenProject();
+		project.setName("PROJECT_STUB_WO_PARENT_WO_PLUGINS_W_EXCLUDES");
+		project.setArtifacts(Set.of(artifact1, artifact2));
+		project.setPluginArtifacts(null);
+		project.setParent(null);
+
+		File pom = getTestFile("src/test/resources/unit-test/pom.xml");
+		DependenciesDataGeneratorMojo mojo = (DependenciesDataGeneratorMojo) lookupMojo("generate", pom);
+		setVariableValueToObject(mojo, "project", project);
+		setVariableValueToObject(mojo, "fileName", "target/test/resources/unit-test/wo-parent-wo-plugins-w-excludes-verify-ok.json");
+		setVariableValueToObject(mojo, "includePlugins", false);
+		setVariableValueToObject(mojo, "includeParent", false);
+		setVariableValueToObject(mojo, "excludes", Map.of("group_1", List.of("artifact_1")));
+
+		mojo.execute();
+
+		try (
+				JsonReader reader1 = new JsonReader(new FileReader(getTestFile("target/test/resources/unit-test/wo-parent-wo-plugins-w-excludes-verify-ok.json")));
+				JsonReader reader2 = new JsonReader(new FileReader(getTestFile("src/test/resources/unit-test/wo-parent-wo-plugins-w-excludes-verify-ok.json")));) {
+			DependenciesData dependenciesData1 = new GsonBuilder()
+					.disableHtmlEscaping()
+					.create()
+					.fromJson(reader1, DependenciesData.class);
+			dependenciesData1.sort();
+
+			DependenciesData dependenciesData2 = new GsonBuilder()
+					.disableHtmlEscaping()
+					.create()
+					.fromJson(reader2, DependenciesData.class);
 			dependenciesData2.sort();
 
 			assertEquals(dependenciesData1.toString(), dependenciesData2.toString());

--- a/src/test/java/it/pagopa/maven/depcheck/DependenciesDataVerifierMojoTest.java
+++ b/src/test/java/it/pagopa/maven/depcheck/DependenciesDataVerifierMojoTest.java
@@ -6,6 +6,8 @@
 package it.pagopa.maven.depcheck;
 
 import java.io.File;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -49,6 +51,38 @@ public class DependenciesDataVerifierMojoTest extends AbstractMojoTestCase {
 		setVariableValueToObject(mojo, "fileName", "src/test/resources/unit-test/wo-parent-wo-plugins-verify-ok.json");
 		setVariableValueToObject(mojo, "includePlugins", false);
 		setVariableValueToObject(mojo, "includeParent", false);
+		mojo.execute();
+	}
+
+	public void testWoParentWoPluginsWExcludesHashOk() throws Exception {
+		MyArtifactStub artifact1 = new MyArtifactStub();
+		artifact1.setId("art_1");
+		artifact1.setArtifactId("artifact_1");
+		artifact1.setFile(getTestFile("src/test/resources/unit-test/artifact_1.txt"));
+		artifact1.setGroupId("group_1");
+		artifact1.setVersion("version_1");
+
+		MyArtifactStub artifact2 = new MyArtifactStub();
+		artifact2.setId("art_2");
+		artifact2.setArtifactId("artifact_2");
+		artifact2.setFile(getTestFile("src/test/resources/unit-test/artifact_2.txt"));
+		artifact2.setGroupId("group_2");
+		artifact2.setVersion("version_2");
+
+		MavenProject project = new MavenProject();
+		project.setName("PROJECT_STUB_WO_PARENT_WO_PLUGINS_W_EXCLUDES");
+		project.setArtifacts(Set.of(artifact1, artifact2));
+		project.setPluginArtifacts(null);
+		project.setParent(null);
+
+		File pom = getTestFile("src/test/resources/unit-test/pom.xml");
+		DependenciesDataVerifierMojo mojo = (DependenciesDataVerifierMojo) lookupMojo("verify", pom);
+		setVariableValueToObject(mojo, "project", project);
+		setVariableValueToObject(mojo, "fileName", "src/test/resources/unit-test/wo-parent-wo-plugins-w-excludes-verify-ok.json");
+		setVariableValueToObject(mojo, "includePlugins", false);
+		setVariableValueToObject(mojo, "includeParent", false);
+		setVariableValueToObject(mojo, "excludes", Map.of("group_1", List.of("artifact_1")));
+
 		mojo.execute();
 	}
 

--- a/src/test/resources/unit-test/wo-parent-wo-plugins-w-excludes-verify-ok.json
+++ b/src/test/resources/unit-test/wo-parent-wo-plugins-w-excludes-verify-ok.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": [
+    {
+      "id": "art_2",
+      "artifactId": "artifact_2",
+      "groupId": "group_2",
+      "version": "version_2",
+      "sha256": "TYB8qTVHft4XP3n_qyd7H6AxU3ukxrhMt0tz2lnRZ1w="
+    }
+  ]
+}


### PR DESCRIPTION
This **PR** adds a feature to exclude some dependencies from hash checking.

**Why?**
In some cases (like [One Identity](https://github.com/pagopa/oneidentity)) we have a common module which we don't want to _version_ for two reasons: 

1. It is a mono-repo project so we don't expect to have a specific version for each module
2. We don't expect to use common layer outside of `One Identity` scope

In these cases, we need to exclude common dependencies from hash checking because the hash itself will always change (for these dependencies) without a version upgrade and the plugin would give an error.

 
